### PR TITLE
Add recently used email list

### DIFF
--- a/popup/config.js
+++ b/popup/config.js
@@ -25,11 +25,25 @@ const setFormValues = async () => {
   });
 };
 
+const setListItems = async () => {
+  const { filledEmails } = await chrome.storage.local.get();
+  const listTag = document.querySelector("ul");
+
+  filledEmails.forEach(email => {
+    const emailNode = document.createTextNode(email);
+    const itemTag = document.createElement("li");
+    itemTag.appendChild(emailNode);
+    listTag.appendChild(itemTag);
+  });
+};
+
 const initializeForm = () => {
   const [form] = document.getElementsByTagName("form");
   form.addEventListener("reset", handleConfigReset);
   form.addEventListener("submit", handleConfigSubmit);
   setFormValues();
+
+  setListItems();
 };
 
 window.addEventListener('load', initializeForm)

--- a/popup/default.html
+++ b/popup/default.html
@@ -19,6 +19,8 @@
         <button type="submit">Update</button>
       </p>
     </form>
+    <p>Recently used emails:</p>
+    <ul></ul>
     <script src="config.js"></script>
   </body>
 </html>

--- a/scripts/fillForm.js
+++ b/scripts/fillForm.js
@@ -1,8 +1,10 @@
 const fillForm = async () => {
-  const { config } = await chrome.storage.local.get();
+  const { config, filledEmails } = await chrome.storage.local.get();
   const form = document.querySelector("form[data-test='SignUpForm']");
   const [firstBit, lastBit] = config.email.split("@");
   const email = `${firstBit}+${Date.now()}@${lastBit}`;
+  filledEmails.push(email);
+  await chrome.storage.local.set({filledEmails});
 
   const fields = [
     { selector: "input[name='name']", value: config.name },

--- a/worker.js
+++ b/worker.js
@@ -10,7 +10,8 @@ chrome.commands.onCommand.addListener(async (command) => {
 
 chrome.runtime.onInstalled.addListener(async () => {
   const initialValues = {
-    config: { email: "user@example.com", name: "Test User" }
+    config: { email: "user@example.com", name: "Test User" },
+    filledEmails: [],
   }
 
   await chrome.storage.local.set(initialValues)


### PR DESCRIPTION
This PR adds a list to the extension popup so that you can find the emails that have recently been used - looks like this:

<img width="350" alt="Screen Shot 2023-01-27 at 1 32 07 PM" src="https://user-images.githubusercontent.com/79799/215180975-9ae4f152-4c1f-418b-a18e-944f5899ff4f.png">

To do this I added a new key to the extension local data called `filledEmails`. It starts life as an empty array and then each time the form is filled in we push an item onto it.

/cc @pam- @laurabeth